### PR TITLE
Fix/change insert to replace between

### DIFF
--- a/__test__/file.test.ts
+++ b/__test__/file.test.ts
@@ -4,7 +4,7 @@ describe("getTemplateFile", () => {
   it("should read and return file contents", async () => {
     const contents = await getTemplateFile("__test__/fixtures/template.md");
     const templateContents =
-      "# This is a template\n<!-- file1.md -->\n<!-- file2.md -->\n";
+      "# This is a template\n\n<!-- file1.md:START -->\n<!-- file1.md:END -->\n\n<!-- file2.md:START -->\n<!-- file2.md:END -->\n";
 
     expect(contents).toEqual(templateContents);
   });

--- a/__test__/fixtures/template.md
+++ b/__test__/fixtures/template.md
@@ -1,3 +1,7 @@
 # This is a template
-<!-- file1.md -->
-<!-- file2.md -->
+
+<!-- file1.md:START -->
+<!-- file1.md:END -->
+
+<!-- file2.md:START -->
+<!-- file2.md:END -->

--- a/__test__/insert.test.ts
+++ b/__test__/insert.test.ts
@@ -1,4 +1,4 @@
-import { insertContentAfterComments } from "../src/lib/file"; // Assuming the updated function name
+import { replaceContentBetweenComments } from "../src/lib/file";
 import { MdFiles } from "../src/lib/types";
 
 const INSERT_DATAS: MdFiles = [
@@ -6,33 +6,37 @@ const INSERT_DATAS: MdFiles = [
   { "file2.md": "Content of file2.md" },
 ];
 
-describe("insertContentAfterComments", () => {
-  it("should insert content after comment placeholders in the template", () => {
-    const template = "# Test\n<!-- file1.md -->\n<!-- file2.md -->";
+describe("replaceContentBetweenComments", () => {
+  it("should replace content between comment placeholders in the template", () => {
+    const template =
+      "# This is a template\n<!-- file1.md:START -->\n<!-- file1.md:END -->\n<!-- file2.md:START -->\n<!-- file2.md:END -->";
     const expectedOutput =
-      "# Test\n<!-- file1.md -->\nContent of file1.md\n<!-- file2.md -->\nContent of file2.md";
+      "# This is a template\n<!-- file1.md:START -->\n\nContent of file1.md\n\n<!-- file1.md:END -->\n<!-- file2.md:START -->\n\nContent of file2.md\n\n<!-- file2.md:END -->";
 
-    const result = insertContentAfterComments(template, INSERT_DATAS);
+    const result = replaceContentBetweenComments(template, INSERT_DATAS);
 
     expect(result).toEqual(expectedOutput);
   });
 
   it("should keep placeholders if content not found in insertDatas", () => {
-    const template = "# Test\n<!-- file1.md -->\n<!-- file3.md -->";
+    const template =
+      "# This is a template\n<!-- file1.md:START -->\n<!-- file1.md:END -->\n<!-- file3.md:START -->\n<!-- file3.md:END -->";
     const expectedOutput =
-      "# Test\n<!-- file1.md -->\nContent of file1.md\n<!-- file3.md -->";
+      "# This is a template\n<!-- file1.md:START -->\n\nContent of file1.md\n\n<!-- file1.md:END -->\n<!-- file3.md:START -->\n<!-- file3.md:END -->";
 
-    const result = insertContentAfterComments(template, INSERT_DATAS);
+    const result = replaceContentBetweenComments(template, INSERT_DATAS);
 
     expect(result).toEqual(expectedOutput);
   });
 
-  it("should not insert content if insertDatas is empty", () => {
-    const template = "# Test\n <!-- file1.md --> \n <!-- file2.md -->";
+  it("should not replace content if insertDatas is empty", () => {
+    const template =
+      "# This is a template\n <!-- file1.md:START --> \n <!-- file2.md:START -->";
     const insertDatas: MdFiles = [];
-    const expectedOutput = "# Test\n <!-- file1.md --> \n <!-- file2.md -->";
+    const expectedOutput =
+      "# This is a template\n <!-- file1.md:START --> \n <!-- file2.md:START -->";
 
-    const result = insertContentAfterComments(template, insertDatas);
+    const result = replaceContentBetweenComments(template, insertDatas);
 
     expect(result).toEqual(expectedOutput);
   });

--- a/dist/index.js
+++ b/dist/index.js
@@ -2802,7 +2802,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.outputMarkdown = exports.insertContentAfterComments = exports.readMdFiles = exports.getTemplateFile = void 0;
+exports.outputMarkdown = exports.replaceContentBetweenComments = exports.readMdFiles = exports.getTemplateFile = void 0;
 const promises_1 = __nccwpck_require__(292);
 const path_1 = __nccwpck_require__(17);
 const fs_1 = __nccwpck_require__(147);
@@ -2850,20 +2850,22 @@ const readMdFiles = (dirPath) => __awaiter(void 0, void 0, void 0, function* () 
 });
 exports.readMdFiles = readMdFiles;
 /**
- * Inserts content from insertDatas after comment placeholders in a template.
+ * Replaces content between comment placeholders with content from insertDatas based on file names.
  *
  * @param {string} template - The template string containing comment placeholders.
  * @param {MdFiles} insertDatas - An array of objects containing markdown content keyed by filenames.
- * @returns {string} The template with content inserted after comment placeholders.
+ * @returns {string} The template with content replaced between comment placeholders.
  */
-const insertContentAfterComments = (template, insertDatas) => {
-    return template.replace(/<!--\s*([a-zA-Z0-9_.-]+)\s*-->/g, (match, fileName) => {
+const replaceContentBetweenComments = (template, insertDatas) => {
+    return template.replace(/<!--\s*([a-zA-Z0-9_.-]+):START\s*-->([\s\S]*?)<!--\s*\1:END\s*-->/g, (match, fileName) => {
         var _a;
         const content = (_a = insertDatas.find((md) => md[fileName])) === null || _a === void 0 ? void 0 : _a[fileName];
-        return content ? `${match}\n${content}` : match;
+        return content
+            ? `<!-- ${fileName}:START -->\n\n${content}\n\n<!-- ${fileName}:END -->`
+            : match;
     });
 };
-exports.insertContentAfterComments = insertContentAfterComments;
+exports.replaceContentBetweenComments = replaceContentBetweenComments;
 /**
  * Writes data to the specified file.
  *
@@ -2916,8 +2918,8 @@ function run() {
         const template = yield (0, file_1.getTemplateFile)(templatePath);
         // Get insert files.
         const insertFiles = yield (0, file_1.readMdFiles)(srcDir);
-        // Replaces comment placeholders in a template and inserts content after comments.
-        const replacedData = (0, file_1.insertContentAfterComments)(template, insertFiles);
+        // Replaces comment placeholders in a template and inserts content between comments.
+        const replacedData = (0, file_1.replaceContentBetweenComments)(template, insertFiles);
         // Output markdown file.
         (0, file_1.outputMarkdown)(replacedData, destFile);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-md-insert",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "About GitHub Action that performs a insert other markdown into a markdown file.",
   "main": "src/main.ts",
   "scripts": {

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -53,21 +53,23 @@ export const readMdFiles = async (dirPath: string): Promise<MdFiles> => {
 };
 
 /**
- * Inserts content from insertDatas after comment placeholders in a template.
+ * Replaces content between comment placeholders with content from insertDatas based on file names.
  *
  * @param {string} template - The template string containing comment placeholders.
  * @param {MdFiles} insertDatas - An array of objects containing markdown content keyed by filenames.
- * @returns {string} The template with content inserted after comment placeholders.
+ * @returns {string} The template with content replaced between comment placeholders.
  */
-export const insertContentAfterComments = (
+export const replaceContentBetweenComments = (
   template: string,
   insertDatas: MdFiles
 ): string => {
   return template.replace(
-    /<!--\s*([a-zA-Z0-9_.-]+)\s*-->/g,
+    /<!--\s*([a-zA-Z0-9_.-]+):START\s*-->([\s\S]*?)<!--\s*\1:END\s*-->/g,
     (match, fileName) => {
       const content = insertDatas.find((md) => md[fileName])?.[fileName];
-      return content ? `${match}\n${content}` : match;
+      return content
+        ? `<!-- ${fileName}:START -->\n\n${content}\n\n<!-- ${fileName}:END -->`
+        : match;
     }
   );
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
 import { getInputParameter } from "./lib/action";
 import {
   getTemplateFile,
-  insertContentAfterComments,
   outputMarkdown,
   readMdFiles,
+  replaceContentBetweenComments,
 } from "./lib/file";
 
 async function run() {
@@ -16,8 +16,8 @@ async function run() {
   // Get insert files.
   const insertFiles = await readMdFiles(srcDir);
 
-  // Replaces comment placeholders in a template and inserts content after comments.
-  const replacedData = insertContentAfterComments(template, insertFiles);
+  // Replaces comment placeholders in a template and inserts content between comments.
+  const replacedData = replaceContentBetweenComments(template, insertFiles);
 
   // Output markdown file.
   outputMarkdown(replacedData, destFile);


### PR DESCRIPTION
## Change:
- Removed unnecessary 'existingContent' variable for improved code clarity.
- Refactored the regular expression pattern for better matching of comment placeholders.
- Updated the function to correctly replace content between comment placeholders.